### PR TITLE
initializeGL(): OSG Viewer realize() method now called, triggering on…

### DIFF
--- a/src/osgQOpenGL/osgQOpenGLWidget.cpp
+++ b/src/osgQOpenGL/osgQOpenGLWidget.cpp
@@ -61,6 +61,7 @@ void osgQOpenGLWidget::initializeGL()
     // Initializes OpenGL function resolution for the current context.
     initializeOpenGLFunctions();
     createRenderer();
+    getOsgViewer()->realize();
     Q_EMIT initialized();
 }
 

--- a/src/osgQOpenGL/osgQOpenGLWindow.cpp
+++ b/src/osgQOpenGL/osgQOpenGLWindow.cpp
@@ -63,6 +63,7 @@ void osgQOpenGLWindow::initializeGL()
     // Initializes OpenGL function resolution for the current context.
     initializeOpenGLFunctions();
     createRenderer();
+    getOsgViewer()->realize();
     Q_EMIT initialized();
 }
 


### PR DESCRIPTION
…-realize callbacks correctly, before the initialized() signal is sent out.