### PR TITLE
aboutToRenderFirstFrame(): New signal on first frame. Some operations…

### DIFF
--- a/include/osgQOpenGL/osgQOpenGLWidget
+++ b/include/osgQOpenGL/osgQOpenGLWidget
@@ -71,6 +71,7 @@ public:
 
 Q_SIGNALS:
     void initialized();
+    void aboutToRenderFirstFrame();
 
 protected:
 

--- a/include/osgQOpenGL/osgQOpenGLWindow
+++ b/include/osgQOpenGL/osgQOpenGLWindow
@@ -75,6 +75,7 @@ public:
 
 Q_SIGNALS:
     void initialized();
+    void aboutToRenderFirstFrame();
 
 protected:
 

--- a/src/osgQOpenGL/osgQOpenGLWidget.cpp
+++ b/src/osgQOpenGL/osgQOpenGLWidget.cpp
@@ -82,6 +82,8 @@ void osgQOpenGLWidget::paintGL()
     if (_isFirstFrame) {
         _isFirstFrame = false;
         m_renderer->getGraphicsContext()->setDefaultFboId(defaultFramebufferObject());
+
+        Q_EMIT aboutToRenderFirstFrame();
     }
     m_renderer->renderFrame();
 }

--- a/src/osgQOpenGL/osgQOpenGLWindow.cpp
+++ b/src/osgQOpenGL/osgQOpenGLWindow.cpp
@@ -80,6 +80,8 @@ void osgQOpenGLWindow::paintGL()
     if (_isFirstFrame) {
         _isFirstFrame = false;
         m_renderer->getGraphicsContext()->setDefaultFboId(defaultFramebufferObject());
+
+        Q_EMIT aboutToRenderFirstFrame();
     }
     m_renderer->renderFrame();
 }


### PR DESCRIPTION
… like getting the GL number of samples, are not available in initializeGL() and need to be tested before rendering first frame.