### PR TITLE
Qt6 Prep: Add -qt5 to Library and Package Name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -764,102 +764,6 @@ IF(APPLE)
 ENDIF()
 
 
-# For Doxygen
-INCLUDE(${CMAKE_ROOT}/Modules/Documentation.cmake OPTIONAL)
-OPTION(BUILD_DOCUMENTATION "Build OpenSceneGraph reference documentation using doxygen (use: make doc_openscenegraph doc_openthreads)" OFF)
-MARK_AS_ADVANCED(CLEAR BUILD_DOCUMENTATION)
-# To build the documention, you will have to enable it
-# and then do the equivalent of "make doc_openscenegraph doc_openthreads".
-IF(BUILD_DOCUMENTATION)
-
-    OPTION(BUILD_REF_DOCS_SEARCHENGINE "Enable doxygen's search engine (requires that documentation to be installed on a php enabled web server)" OFF)
-    IF(BUILD_REF_DOCS_SEARCHENGINE)
-        SET(SEARCHENGINE YES)
-    ELSE()
-        SET(SEARCHENGINE NO)
-    ENDIF()
-
-    OPTION(BUILD_REF_DOCS_TAGFILE "Generate a tag file named osg.tag on the documentation web server" OFF)
-    IF(BUILD_REF_DOCS_TAGFILE)
-        SET(GENERATE_TAGFILE "${OpenSceneGraph_BINARY_DIR}/doc/OpenSceneGraphReferenceDocs/osg.tag")
-    ELSE()
-        SET(GENERATE_TAGFILE "")
-    ENDIF()
-
-    IF(DOT)
-        SET(HAVE_DOT YES)
-    ELSE()
-        SET(HAVE_DOT NO)
-    ENDIF()
-
-    # If html help generation was requested. DOCUMENTATION_HTML_HELP is defined by Documentation.cmake
-    SET(GENERATE_HTMLHELP "NO")
-    IF(DOCUMENTATION_HTML_HELP)
-        # on windows Documentation.cmake finds the html help workshop if it exists. On u*ix we might have it with wine but no way to point it out
-        IF(NOT WIN32)
-            SET(HTML_HELP_COMPILER "" CACHE FILEPATH "Enter location of the HTML help compiler to let doxygen compile html")
-            MARK_AS_ADVANCED(HTML_HELP_COMPILER)
-        ENDIF()
-        # this var sets a proper value in .doxygen files when configuring them below
-        SET(GENERATE_HTMLHELP "YES")
-    endif()
-
-    # This processes our doxyfile.cmake and substitutes paths to generate
-    # a final Doxyfile
-    CONFIGURE_FILE(${PROJECT_SOURCE_DIR}/doc/Doxyfiles/doxyfile.cmake
-        ${PROJECT_BINARY_DIR}/doc/openscenegraph.doxyfile
-    )
-    # copy the osg logo to documentations target folder
-    CONFIGURE_FILE(${PROJECT_SOURCE_DIR}/PlatformSpecifics/Windows/icons/src/osg32-32.png
-        ${PROJECT_BINARY_DIR}/doc/OpenSceneGraphReferenceDocs/osg32-32.png COPYONLY
-    )
-    #INSTALL(FILES ${PROJECT_BINARY_DIR}/doc/${PROJECT_NAME}ReferenceDocs-${OPENSCENEGRAPH_VERSION}.chm DESTINATION doc OPTIONAL COMPONENT openscenegraph-doc)
-    INSTALL(DIRECTORY ${PROJECT_BINARY_DIR}/doc/OpenSceneGraphReferenceDocs DESTINATION doc COMPONENT openscenegraph-doc)
-
-    # now set up openthreads documentation generation
-    IF(BUILD_REF_DOCS_TAGFILE)
-        SET(GENERATE_TAGFILE "${OpenSceneGraph_BINARY_DIR}/doc/OpenThreadsReferenceDocs/ot.tag")
-    ENDIF()
-
-    # copy the osg logo to documentations target folder
-    CONFIGURE_FILE(${PROJECT_SOURCE_DIR}/PlatformSpecifics/Windows/icons/src/osg32-32.png
-        ${PROJECT_BINARY_DIR}/doc/OpenThreadsReferenceDocs/osg32-32.png COPYONLY
-    )
-    #INSTALL(FILES ${PROJECT_BINARY_DIR}/doc/${PROJECT_NAME}ReferenceDocs-${OPENSCENEGRAPH_VERSION}.chm DESTINATION doc OPTIONAL COMPONENT openscenegraph-doc)
-    INSTALL(DIRECTORY ${PROJECT_BINARY_DIR}/doc/OpenThreadsReferenceDocs DESTINATION doc COMPONENT openthreads-doc)
-
-    # Process our other doxyfiles but don't create targets for these
-    CONFIGURE_FILE(${PROJECT_SOURCE_DIR}/doc/Doxyfiles/all_Doxyfile
-        ${PROJECT_BINARY_DIR}/doc/all_Doxyfile)
-    CONFIGURE_FILE(${PROJECT_SOURCE_DIR}/doc/Doxyfiles/auto_Doxyfile
-        ${PROJECT_BINARY_DIR}/doc/auto_Doxyfile)
-    CONFIGURE_FILE(${PROJECT_SOURCE_DIR}/doc/Doxyfiles/core_Doxyfile
-        ${PROJECT_BINARY_DIR}/doc/core_Doxyfile)
-
-    # This creates a new target to build documentation.
-    # It runs ${DOXYGEN} which is the full path and executable to
-    # Doxygen on your system, set by the FindDoxygen.cmake module
-    # (called by FindDocumentation.cmake).
-    # It runs the final generated Doxyfile against it.
-    # The DOT_PATH is substituted into the Doxyfile.
-    ADD_CUSTOM_TARGET(doc_openscenegraph ${DOXYGEN}
-        ${PROJECT_BINARY_DIR}/doc/openscenegraph.doxyfile
-    )
-    SET_TARGET_PROPERTIES(doc_openscenegraph PROPERTIES FOLDER "Documentation")
-
-    ADD_CUSTOM_TARGET(doc_openthreads ${DOXYGEN}
-        ${PROJECT_BINARY_DIR}/doc/openthreads.doxyfile
-    )
-    SET_TARGET_PROPERTIES(doc_openthreads PROPERTIES FOLDER "Documentation")
-ENDIF(BUILD_DOCUMENTATION)
-
-OPTION(BUILD_DASHBOARD_REPORTS "Set to ON to activate reporting of OpenSceneGraph builds here http://cdash.openscenegraph.org/index.php?project=OpenSceneGraph" OFF)
-IF(BUILD_DASHBOARD_REPORTS)
-# The following are required to uses Dart and the Cdash dashboard
-# viewable here : http://cdash.openscenegraph.org/index.php?project=OpenSceneGraph
-    INCLUDE(Dart)
-ENDIF()
-
 # present the packaging option only if we have the cpack command defined (effectively >= 2.6.0)
 IF(CMAKE_CPACK_COMMAND)
     OPTION(BUILD_OSG_PACKAGES "Set to ON to generate CPack configuration files and packaging targets" OFF)
@@ -867,16 +771,6 @@ IF(CMAKE_CPACK_COMMAND)
       INCLUDE(OsgCPack)
     ENDIF()
 ENDIF()
-
-# Generate pkg-config configuration files
-    SET ( PKGCONFIG_MODULE_NAME osgQt )
-
-CONFIGURE_FILE(${PROJECT_SOURCE_DIR}/packaging/pkgconfig/openscenegraph-osgQt.pc.in
-  ${PROJECT_BINARY_DIR}/packaging/pkgconfig/openscenegraph-${PKGCONFIG_MODULE_NAME}.pc
-  @ONLY
-  )
-INSTALL(FILES ${PROJECT_BINARY_DIR}/packaging/pkgconfig/openscenegraph-${PKGCONFIG_MODULE_NAME}.pc DESTINATION lib${LIB_POSTFIX}/pkgconfig COMPONENT libopenscenegraph-dev)
-
 
 # Run this as late as possible so users can easier spot the message
 IF (NOT DEFINED REQUIRES_LIBPATH_MESSAGE AND ${CMAKE_INSTALL_PREFIX} STREQUAL "/usr/local")
@@ -938,33 +832,3 @@ CONFIGURE_FILE(
   IMMEDIATE @ONLY)
 ADD_CUSTOM_TARGET(uninstall
   "${CMAKE_COMMAND}" -P "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake")
-
-install(TARGETS osgQOpenGL
-    EXPORT osgQOpenGL-targets
-)
-
-install(EXPORT osgQOpenGL-targets
-    FILE osgQOpenGLTargets.cmake
-    NAMESPACE osgQt::
-    DESTINATION "share/cmake/osgQOpenGL"
-)
-
-include(CMakePackageConfigHelpers)
-
-configure_package_config_file(
-    "osgQOpenGLConfig.cmake.in"
-    "${CMAKE_CURRENT_BINARY_DIR}/osgQOpenGLConfig.cmake"
-    INSTALL_DESTINATION "share/cmake/osgQOpenGL"
-)
-
-write_basic_package_version_file(
-    "osgQOpenGLConfigVersion.cmake"
-    VERSION ${OSGQOPENGL_VERSION}
-    COMPATIBILITY SameMajorVersion
-)
-
-install(FILES
-    "${CMAKE_CURRENT_BINARY_DIR}/osgQOpenGLConfig.cmake"
-    "${CMAKE_CURRENT_BINARY_DIR}/osgQOpenGLConfigVersion.cmake"
-    DESTINATION "share/cmake/osgQOpenGL"
-)

--- a/src/osgQOpenGL/CMakeLists.txt
+++ b/src/osgQOpenGL/CMakeLists.txt
@@ -1,50 +1,93 @@
-IF ( Qt5Widgets_FOUND )
-    include(GenerateExportHeader)
-
-    SET(LIB_NAME osgQOpenGL)
-    SET(HEADER_INSTALL_DIR osgQOpenGL)
-
-    set(CMAKE_INCLUDE_CURRENT_DIR yes)
-
-    SET(HEADER_PATH ../../include/osgQOpenGL)
-
-    SET(SOURCE_H 
-        ${HEADER_PATH}/osgQOpenGLWidget
-        ${HEADER_PATH}/osgQOpenGLWindow
-        ${HEADER_PATH}/OSGRenderer
-    )
-
-    qt5_wrap_cpp(SOURCES_H_MOC ${SOURCE_H} #[[OPTIONS ${MOC_OPTIONS}]])
-
-    SET(TARGET_H
-        ${SOURCE_H}
-        ${CMAKE_CURRENT_BINARY_DIR}/Export
-        ${OSGQOPENGL_VERSION_HEADER}
-    )
+if(TARGET Qt6::OpenGL)
+    set(QT_VERSION_MAJOR 6)
+elseif(TARGET Qt5::OpenGL)
+    set(QT_VERSION_MAJOR 5)
+else()
+    return()
+endif()
 
 
-    SET(TARGET_SRC
-        osgQOpenGLWidget.cpp
-        osgQOpenGLWindow.cpp
-        OSGRenderer.cpp
-        Version.cpp
-        ${SOURCES_H_MOC}
-        ${OPENSCENEGRAPH_VERSIONINFO_RC}
-    )
+include(GenerateExportHeader)
 
-    SET(TARGET_LIBRARIES Qt5::Widgets Qt5::OpenGL)
-    SET(TARGET_LIBRARIES_VARS
-        OSG_LIBRARY
-        OSGUTIL_LIBRARY
-        OSGVIEWER_LIBRARY
-        OSGGA_LIBRARY
-        OSGDB_LIBRARY
-        OPENTHREADS_LIBRARY
-    )
+option(OSGQOPENGL_APPEND_QT_VERSION "Append the Qt major version to the library name (e.g., mylib-qt6)" ON)
+set(LIB_NAME osgQOpenGL)
+if(OSGQOPENGL_APPEND_QT_VERSION)
+    set(LIB_NAME ${LIB_NAME}-qt${QT_VERSION_MAJOR})
+endif()
 
-    SETUP_LIBRARY(${LIB_NAME})
 
-    target_include_directories(${LIB_NAME} PUBLIC $<INSTALL_INTERFACE:include>)
-    generate_export_header(${LIB_NAME} EXPORT_FILE_NAME "Export")
+set(HEADER_INSTALL_DIR osgQOpenGL)
+set(CMAKE_INCLUDE_CURRENT_DIR yes)
+set(HEADER_PATH ../../include/osgQOpenGL)
 
-ENDIF()
+set(SOURCE_H
+    ${HEADER_PATH}/osgQOpenGLWidget
+    ${HEADER_PATH}/osgQOpenGLWindow
+    ${HEADER_PATH}/OSGRenderer
+)
+
+qt_wrap_cpp(SOURCES_H_MOC ${SOURCE_H})
+
+set(TARGET_H
+    ${SOURCE_H}
+    ${CMAKE_CURRENT_BINARY_DIR}/Export
+    ${OSGQOPENGL_VERSION_HEADER}
+)
+
+set(TARGET_SRC
+    osgQOpenGLWidget.cpp
+    osgQOpenGLWindow.cpp
+    OSGRenderer.cpp
+    Version.cpp
+    ${SOURCES_H_MOC}
+    ${OPENSCENEGRAPH_VERSIONINFO_RC}
+)
+
+set(TARGET_LIBRARIES Qt${QT_VERSION_MAJOR}::Widgets Qt${QT_VERSION_MAJOR}::OpenGL)
+set(TARGET_LIBRARIES_VARS
+    OSG_LIBRARY
+    OSGUTIL_LIBRARY
+    OSGVIEWER_LIBRARY
+    OSGGA_LIBRARY
+    OSGDB_LIBRARY
+    OPENTHREADS_LIBRARY
+)
+
+SETUP_LIBRARY(${LIB_NAME})
+target_include_directories(${LIB_NAME} PUBLIC $<INSTALL_INTERFACE:include>)
+generate_export_header(${LIB_NAME} BASE_NAME osgQOpenGL EXPORT_FILE_NAME "Export")
+
+# Add an alias target for the latest version
+if(OSGQOPENGL_APPEND_QT_VERSION)
+    add_library(osgQOpenGL ALIAS ${LIB_NAME})
+endif()
+
+install(TARGETS ${LIB_NAME}
+    EXPORT ${LIB_NAME}-targets
+)
+
+install(EXPORT ${LIB_NAME}-targets
+    FILE osgQOpenGLTargets.cmake
+    NAMESPACE osgQt::
+    DESTINATION "share/cmake/${LIB_NAME}"
+)
+
+include(CMakePackageConfigHelpers)
+
+configure_package_config_file(
+    "osgQOpenGLConfig.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/${LIB_NAME}Config.cmake"
+    INSTALL_DESTINATION "share/cmake/${LIB_NAME}"
+)
+
+write_basic_package_version_file(
+    "${LIB_NAME}ConfigVersion.cmake"
+    VERSION ${OSGQOPENGL_VERSION}
+    COMPATIBILITY SameMajorVersion
+)
+
+install(FILES
+    "${CMAKE_CURRENT_BINARY_DIR}/${LIB_NAME}Config.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/${LIB_NAME}ConfigVersion.cmake"
+    DESTINATION "share/cmake/${LIB_NAME}"
+)

--- a/src/osgQOpenGL/osgQOpenGLConfig.cmake.in
+++ b/src/osgQOpenGL/osgQOpenGLConfig.cmake.in
@@ -1,4 +1,4 @@
-if(TARGET osgQt::osgQOpenGL)
+if(TARGET osgQt::@LIB_NAME@)
     set(_OSGQOPENGL_ALREADY_DEFINED ON)
 endif()
 
@@ -16,7 +16,14 @@ if(NOT _OSGQOPENGL_ALREADY_DEFINED)
     # Replace the interface link libraries with those found by OSG, to allow this to be more easily relocatable.
     # Without this, absolute paths to OSG are stored in the target, making the output library non-relocatable
     # to other machines unless they have OSG in the exact same location.
-    set_target_properties(osgQt::osgQOpenGL PROPERTIES INTERFACE_LINK_LIBRARIES "Qt5::Widgets;Qt5::OpenGL")
-    target_link_libraries(osgQt::osgQOpenGL INTERFACE ${OPENSCENEGRAPH_LIBRARIES})
-    target_include_directories(osgQt::osgQOpenGL INTERFACE ${OPENSCENEGRAPH_INCLUDE_DIRS})
+    set_target_properties(osgQt::@LIB_NAME@ PROPERTIES INTERFACE_LINK_LIBRARIES "Qt@QT_VERSION_MAJOR@::Widgets;Qt@QT_VERSION_MAJOR@::OpenGL")
+    target_link_libraries(osgQt::@LIB_NAME@ INTERFACE ${OPENSCENEGRAPH_LIBRARIES})
+    target_include_directories(osgQt::@LIB_NAME@ INTERFACE ${OPENSCENEGRAPH_INCLUDE_DIRS})
+endif()
+
+# Add an alias as needed
+if(NOT TARGET osgQt::osgQOpenGL)
+    if(TARGET osgQt::osgQOpenGL-qt@QT_VERSION_MAJOR@)
+        add_library(osgQt::osgQOpenGL ALIAS osgQt::osgQOpenGL-qt@QT_VERSION_MAJOR@)
+    endif()
 endif()


### PR DESCRIPTION
Moved install commands into src/osgQOpenGL; removed pkgconfig; removed deprecated Documentation use; Removed OSG Dart use; new OSGQOPENGL_APPEND_QT_VERSION defaults on. When on, library name is updated to include -qt5 at the end, impacting find_package, and osgQt::osgQOpenGL is created as an alias library.