### PR TITLE
Qt6: Support for Qt6; it is preferred in find_package, but Qt5 will work too.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,7 @@ IF(APPLE)
   ENDIF()
 ENDIF()
 
-PROJECT(osgQt VERSION ${OSGQOPENGL_VERSION} LANGUAGES CXX)
+PROJECT(osgQOpenGL VERSION ${OSGQOPENGL_VERSION} LANGUAGES CXX)
 
 INCLUDE(GNUInstallDirs)
 FIND_PACKAGE(OpenSceneGraph 3.6.0 REQUIRED osgDB osgGA osgUtil osgText osgViewer osgWidget)
@@ -438,7 +438,14 @@ INCLUDE(OsgMacroUtils)
 # via cmake -DDESIRED_QT_VERSION=5
 # QUIET option disables messages if the package cannot be found.
 
-FIND_PACKAGE(Qt5 COMPONENTS Widgets OpenGL REQUIRED)
+# Try to find Qt6, then Qt5, and if both fail give an error message
+find_package(Qt6 COMPONENTS Widgets OpenGL OpenGLWidgets QUIET)
+if(NOT Qt6_FOUND)
+    find_package(Qt5 COMPONENTS Widgets OpenGL QUIET)
+    if(NOT Qt5_FOUND)
+        message(FATAL_ERROR "Could not find either Qt6 or Qt5. This project requires Qt.")
+    endif()
+endif()
 
 
 ################################################################################

--- a/src/osgQOpenGL/CMakeLists.txt
+++ b/src/osgQOpenGL/CMakeLists.txt
@@ -43,7 +43,14 @@ set(TARGET_SRC
     ${OPENSCENEGRAPH_VERSIONINFO_RC}
 )
 
-set(TARGET_LIBRARIES Qt${QT_VERSION_MAJOR}::Widgets Qt${QT_VERSION_MAJOR}::OpenGL)
+if(QT_VERSION_MAJOR EQUAL 5)
+    set(TARGET_LIBRARIES Qt5::Widgets Qt5::OpenGL)
+    set(_QT_COMPONENTS "Widgets OpenGL")
+else()
+    set(TARGET_LIBRARIES Qt6::Widgets Qt6::OpenGL Qt6::OpenGLWidgets)
+    set(_QT_COMPONENTS "Widgets OpenGL OpenGLWidgets")
+endif()
+
 set(TARGET_LIBRARIES_VARS
     OSG_LIBRARY
     OSGUTIL_LIBRARY
@@ -67,7 +74,7 @@ install(TARGETS ${LIB_NAME}
 )
 
 install(EXPORT ${LIB_NAME}-targets
-    FILE osgQOpenGLTargets.cmake
+    FILE ${LIB_NAME}Targets.cmake
     NAMESPACE osgQt::
     DESTINATION "share/cmake/${LIB_NAME}"
 )

--- a/src/osgQOpenGL/OSGRenderer.cpp
+++ b/src/osgQOpenGL/OSGRenderer.cpp
@@ -262,7 +262,7 @@ void OSGRenderer::mousePressEvent(QMouseEvent* event)
         button = 1;
         break;
 
-    case Qt::MidButton:
+    case Qt::MiddleButton:
         button = 2;
         break;
 
@@ -294,7 +294,7 @@ void OSGRenderer::mouseReleaseEvent(QMouseEvent* event)
         button = 1;
         break;
 
-    case Qt::MidButton:
+    case Qt::MiddleButton:
         button = 2;
         break;
 
@@ -326,7 +326,7 @@ void OSGRenderer::mouseDoubleClickEvent(QMouseEvent* event)
         button = 1;
         break;
 
-    case Qt::MidButton:
+    case Qt::MiddleButton:
         button = 2;
         break;
 
@@ -358,6 +358,8 @@ void OSGRenderer::mouseMoveEvent(QMouseEvent* event)
 void OSGRenderer::wheelEvent(QWheelEvent* event)
 {
     setKeyboardModifiers(event);
+
+#if QT_VERSION_MAJOR == 5
     m_osgWinEmb->getEventQueue()->mouseMotion(event->x() * m_windowScale,
                                               event->y() * m_windowScale);
     m_osgWinEmb->getEventQueue()->mouseScroll(
@@ -366,6 +368,15 @@ void OSGRenderer::wheelEvent(QWheelEvent* event)
          osgGA::GUIEventAdapter::SCROLL_DOWN) :
         (event->delta() > 0 ? osgGA::GUIEventAdapter::SCROLL_LEFT :
          osgGA::GUIEventAdapter::SCROLL_RIGHT));
+#else
+    m_osgWinEmb->getEventQueue()->mouseMotion(event->position().x() * m_windowScale,
+                                              event->position().y() * m_windowScale);
+    m_osgWinEmb->getEventQueue()->mouseScroll(
+      (event->angleDelta().y() > 0 ? osgGA::GUIEventAdapter::SCROLL_UP :
+        (event->angleDelta().y() < 0 ? osgGA::GUIEventAdapter::SCROLL_DOWN :
+          (event->angleDelta().x() > 0 ? osgGA::GUIEventAdapter::SCROLL_LEFT :
+            osgGA::GUIEventAdapter::SCROLL_RIGHT))));
+#endif
 }
 
 // called from ViewerWidget paintGL() method

--- a/src/osgQOpenGL/osgQOpenGLConfig.cmake.in
+++ b/src/osgQOpenGL/osgQOpenGLConfig.cmake.in
@@ -4,19 +4,19 @@ endif()
 
 include(CMakeFindDependencyMacro)
 
-find_dependency(Qt5 COMPONENTS Widgets OpenGL)
+find_dependency(Qt5 COMPONENTS @_QT_COMPONENTS@)
 # Instead of checking OPENSCENEGRAPH_LIBRARIES, check osgViewer and osgUtil specifically
 if(NOT DEFINED OSGUTIL_LIBRARIES OR NOT DEFINED OSGVIEWER_LIBRARIES OR NOT DEFINED OPENSCENEGRAPH_INCLUDE_DIRS)
     find_dependency(OpenSceneGraph COMPONENTS osgUtil osgViewer)
 endif()
 
-include("${CMAKE_CURRENT_LIST_DIR}/osgQOpenGLTargets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/@LIB_NAME@Targets.cmake")
 
 if(NOT _OSGQOPENGL_ALREADY_DEFINED)
     # Replace the interface link libraries with those found by OSG, to allow this to be more easily relocatable.
     # Without this, absolute paths to OSG are stored in the target, making the output library non-relocatable
     # to other machines unless they have OSG in the exact same location.
-    set_target_properties(osgQt::@LIB_NAME@ PROPERTIES INTERFACE_LINK_LIBRARIES "Qt@QT_VERSION_MAJOR@::Widgets;Qt@QT_VERSION_MAJOR@::OpenGL")
+    set_target_properties(osgQt::@LIB_NAME@ PROPERTIES INTERFACE_LINK_LIBRARIES "@TARGET_LIBRARIES@")
     target_link_libraries(osgQt::@LIB_NAME@ INTERFACE ${OPENSCENEGRAPH_LIBRARIES})
     target_include_directories(osgQt::@LIB_NAME@ INTERFACE ${OPENSCENEGRAPH_INCLUDE_DIRS})
 endif()


### PR DESCRIPTION
Includes other minor fixes like project name, and setting the Target.cmake file more correctly.